### PR TITLE
Add basic info viewing to dashboard

### DIFF
--- a/APICurious-GitHub/app/models/follow.rb
+++ b/APICurious-GitHub/app/models/follow.rb
@@ -1,0 +1,20 @@
+class Follow < OpenStruct
+  attr_reader :service
+
+  def self.service
+    @service ||= GithubService.new
+  end
+
+  def self.followers(username)
+    service.followers(username).map do |follower|
+      Follow.new(follower)
+    end
+  end
+
+  def self.following(username)
+    service.following(username).map do |followed|
+      Follow.new(followed)
+    end
+  end
+
+end

--- a/APICurious-GitHub/app/models/repository.rb
+++ b/APICurious-GitHub/app/models/repository.rb
@@ -1,0 +1,12 @@
+class Repository < OpenStruct
+  attr_reader :service
+
+  def self.service
+    @service ||= GithubService.new
+  end
+
+  def self.count_of_starred(username)
+    service.starred_repositories(username).count
+  end
+
+end

--- a/APICurious-GitHub/app/models/user.rb
+++ b/APICurious-GitHub/app/models/user.rb
@@ -9,4 +9,16 @@ class User < ApplicationRecord
       user
     end
 
+    def followers
+      Follow.followers(self.name)
+    end
+
+    def following
+      Follow.following(self.name)
+    end
+
+    def starred_count
+      Repository.count_of_starred(self.name)
+    end
+
 end

--- a/APICurious-GitHub/app/services/github_service.rb
+++ b/APICurious-GitHub/app/services/github_service.rb
@@ -1,0 +1,32 @@
+class GithubService
+  attr_reader :connection, :username, :auth
+
+  def initialize
+    @connection = Faraday.new('https://api.github.com')
+    @username   = username
+    @auth       = "?client_id=#{ENV['GITHUB_KEY']}&client_secret=#{ENV['GITHUB_SECRET']}"
+  end
+
+  def repositories(username)
+    parse(connection.get("/users/#{username}/repos#{auth}"))
+  end
+
+  def followers(username)
+    parse(connection.get("/users/#{username}/followers#{auth}"))
+  end
+
+  def starred_repositories(username)
+    parse(connection.get("/users/#{username}/starred#{auth}"))
+  end
+
+  def following(username)
+    parse(connection.get("/users/#{username}/following#{auth}"))
+  end
+
+
+  private
+
+  def parse(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/APICurious-GitHub/app/views/dashboard/show.html.erb
+++ b/APICurious-GitHub/app/views/dashboard/show.html.erb
@@ -16,17 +16,28 @@
 <div class='row text-center'>
   <div class='col-md-4'>
     <p>
-      Placeholder for info
+      Starred Repository Count: <%= current_user.starred_count %>
     </p>
   </div>
   <div class='col-md-4'>
-    <p>
-      Placeholder for info
-    </p>
+    <h4> Followers</h4>
+    <ul>
+      <% current_user.followers.each do |follower|  %>
+        <li>
+          <a href="<%= follower.html_url %>"><%= follower.login %></a>
+        </li>
+      <% end %>
+    </ul>
+
   </div>
   <div class='col-md-4'>
-    <p>
-      Placeholder for info
-    </p>
+    <h4>Following:</h4>
+    <ul>
+      <% current_user.following.each do |followed| %>
+      <li>
+        <a href="<%= followed.html_url %>"><%= followed.login %></a>
+      </li>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/APICurious-GitHub/app/views/homes/show.html.erb
+++ b/APICurious-GitHub/app/views/homes/show.html.erb
@@ -3,7 +3,7 @@
     <div class="jumbotron">
       <h1>Welcome to the GitHub Digester.</h1>
       <h3 align='center'>Most of this definitely worked the first try...or two.</h3>
-      <p id=login_button align='center'><a class="btn btn-danger btn-lg" href="http://github.com/login/oauth/authorize?client_id=<%=ENV['GITHUB_KEY']%>&scope=repo" role="button">GitHub Login</a></p>
+      <p id=login_button align='center'><a class="btn btn-danger btn-lg" href="http://github.com/login/oauth/authorize?client_id=<%=ENV['GITHUB_KEY']%>&scope=repo%20user" role="button">GitHub Login</a></p>
     </div>
   </div>
   <img src="https://d13yacurqjgara.cloudfront.net/users/420183/screenshots/2875637/octocat_github.gif" width='100%'>

--- a/APICurious-GitHub/spec/models/follow_spec.rb
+++ b/APICurious-GitHub/spec/models/follow_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Follow do
+  describe '#followers' do
+    it 'returns array of follows the user is following' do
+      followed = Follow.followers('andrewdwooten')
+      first = followed.first
+
+      expect(followed.count).to eq(1)
+      expect(first.login).to eq('CjMoore')
+    end
+  end
+  describe '#following' do
+    it 'returns array of followers the user is following' do
+      following = Follow.following('andrewdwooten')
+      first = following.first
+
+      byebug
+
+      expect(following.count).to eq(1)
+      expect(first.login).to eq('blackknight75')
+    end
+  end
+end

--- a/APICurious-GitHub/spec/models/repository_spec.rb
+++ b/APICurious-GitHub/spec/models/repository_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Repository do
+  describe '#count_of_starred' do
+    it 'finds count of repositories starred by current_user' do
+      star_count = Repository.count_of_starred('andrewdwooten')
+
+      expect(star_count).to eq(1)
+    end
+  end
+end

--- a/APICurious-GitHub/spec/services/github_services_spec.rb
+++ b/APICurious-GitHub/spec/services/github_services_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe GithubService do
+  attr_reader :service
+
+  before(:each) do
+    @service = GithubService.new
+  end
+
+  describe '#repositories' do
+  it 'finds all user repositories' do
+    repositories = @service.repositories('andrewdwooten')
+    repository = repositories.first
+
+    expect(repositories.count).to eq(28)
+    expect(repository[:name]).to eq("advanced_enumerables")
+  end
+end
+
+  describe '#followers' do
+    it 'finds all users followers' do
+      followers = @service.followers('andrewdwooten')
+      follower = followers.first
+
+      expect(followers.count).to eq(1)
+      expect(follower[:login]).to eq('CjMoore')
+    end
+  end
+
+  describe '#starred' do
+    it 'finds the starred repos of a user' do
+      starred = @service.starred_repositories('andrewdwooten')
+      star = starred.first
+
+      expect(starred.count).to eq(1)
+      expect(star[:name]).to eq('portfolios')
+    end
+  end
+
+  describe '#following' do
+    it 'finds users the current user is following' do
+      following = @service.following('andrewdwooten')
+      followed = following.first
+
+      expect(following.count).to eq(1)
+      expect(followed[:login]).to eq('blackknight75')
+    end
+  end
+
+end


### PR DESCRIPTION
Adds github service to hit api
and retrieve data for required
queries. Adds both a repository
and a follow PORO to to interact
with github_service and return
appropriately formatted data.
Methods added to user which
interacted with necessary POROs
to complete calls and return
data for the appropriate user.