### PR TITLE
Refactor commit.rb method

### DIFF
--- a/APICurious-GitHub/app/models/commit.rb
+++ b/APICurious-GitHub/app/models/commit.rb
@@ -6,19 +6,29 @@ class Commit < OpenStruct
   end
 
   def self.recent(username)
-    commits = []
     repo_names = service.repositories(username).map do |repo|
                     repo[:name]
                  end
     repo_commits = repo_names.map do |repo|
       service.commits(username, repo)
     end
+    clear_empty_repos(repo_commits, username)
+  end
+
+  def self.clear_empty_repos(repo_commits, username)
     repo_commits.delete_if {|repo| repo.empty? || repo.class == Hash}
+    format_commits(repo_commits, username)
+  end
+
+  def self.format_commits(repo_commits, username)
+    commits = []
     repo_commits.each do |repo|
       repo.each do |commit|
+        if commit[:commit][:author][:name] == username
         commits << Commit.new({date:     commit[:commit][:author][:date].to_time.in_time_zone,
-                  repo_url: commit[:html_url],
-                  message:  commit[:commit][:message]})
+                               repo_url: commit[:html_url],
+                               message:  commit[:commit][:message]})
+        end
       end
     end
     commits[0..9]


### PR DESCRIPTION
Breaks logic out of obtaining recent
commits in commit PORO. Also adds
a line to only take commits that are
tagged by with the users username.
All tests remain passing.